### PR TITLE
Eliminate debugger's dependencies on main.js

### DIFF
--- a/src/debugger.js
+++ b/src/debugger.js
@@ -1,5 +1,4 @@
 import { getStepInto, isPrimative, setStepInto, stepButton, stepIntoButton, stopButton } from "./common";
-import { embedMode, parameters } from "./main";
 
 export function showDebug() {
     let debugOptions = document.querySelectorAll('.debugOptions');
@@ -13,16 +12,14 @@ export function showDebug() {
     document.querySelector('#runButton').style.display = 'none';
 }
 
-export function hideDebug() {
+export function hideDebug(showRunButton) {
     let debugOptions = document.querySelectorAll('.debugOptions');
     let debug = document.getElementById('debug') ?? document.getElementById('DebugButton');
     let variableTableContainer = document.getElementById('Variable-table-container');
     for (let button of debugOptions) {
         button.style.display = 'none';
     }
-    if (!embedMode) {
-        document.querySelector('#runButton').style.display = 'block';
-    } else if (embedMode && (parameters.get('button') === 'both')){
+    if (showRunButton) {
         document.querySelector('#runButton').style.display = 'block';
     }
     debug.style.display = 'block';

--- a/src/main.js
+++ b/src/main.js
@@ -278,7 +278,7 @@ function registerListeners() {
   });
 
   stopButton.addEventListener('click', function () {
-    hideDebug();
+    hideDebug(!embedMode || parameters.get('button') === 'both');
     setDebugMode(false);
     setStepInto(false);
     stepButton.click();


### PR DESCRIPTION
We must not import from `main.js`. Doing so causes `initialize` to run again. which is redundant at best and generates an error with Blockly at the worst. In this case, I think we can just replace the dependencies with a parameter. There may be a better fix. I defer to Ellona.

In general, if another file needs a function that is in `main.js`, we should pull it out to a "library" file. If another file needs a global that is in `main.js`, it should receive that global as a parameter rather than importing it.