### PR TITLE
Add array create expressions

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -528,17 +528,25 @@ class Praxly_array_create {
                 `(Actual: ${length.realType})`, this.json.line);
         }
         length = length.value;
+        if (length < 0) {
+            throw new PraxlyError(`Array length must be nonnegative ` +
+                `(Actual: ${length})`, this.json.line);
+        }
         // default value for new array of n elements
         let value;
         switch (this.elemType) {
             case TYPES.BOOLEAN:
                 value = false;
+                break;
             case TYPES.CHAR:
                 value = "0";  // null character not in language
+                break;
             case TYPES.STRING:
-                value = "0";  // null reference not implemented
+                value = "";   // null reference not implemented
+                break;
             default:
                 value = 0;
+                break;
         }
         // construct the array of n default values
         let elements = [];

--- a/src/ast.js
+++ b/src/ast.js
@@ -337,7 +337,7 @@ export function createExecutable(tree) {
             return new Praxly_array_literal(args, tree);
 
         case NODETYPES.ARRAY_CREATE:
-            return new Praxly_array_create(tree.elemType, tree.varType, tree.arrayLength,tree);
+            return new Praxly_array_create(tree.elemType, tree.varType, tree.arrayLength, tree);
 
         case NODETYPES.ARRAY_REFERENCE:
             return new Praxly_array_reference(tree.name, createExecutable(tree.index), tree);
@@ -356,7 +356,6 @@ export function createExecutable(tree) {
 class Praxly_single_line_comment {
 
     constructor(value, node) {
-        this.jsonType = 'Praxly_single_line_comment';
         this.json = node;
         this.value = value;
     }
@@ -368,7 +367,6 @@ class Praxly_single_line_comment {
 class Praxly_comment {
 
     constructor(value, node) {
-        this.jsonType = 'Praxly_comment';
         this.json = node;
         this.value = value;
     }
@@ -380,7 +378,6 @@ class Praxly_comment {
 class Praxly_int {
 
     constructor(value, node) {
-        this.jsonType = 'Praxly_int';
         this.json = node;
         this.value = Math.floor(value);
         this.realType = TYPES.INT;
@@ -394,7 +391,6 @@ class Praxly_int {
 class Praxly_short {
 
     constructor(value, node) {
-        this.jsonType = 'Praxly_int';
         this.json = node;
         this.value = Math.floor(value);
         this.realType = TYPES.SHORT;
@@ -408,7 +404,6 @@ class Praxly_short {
 class Praxly_double {
 
     constructor(value, node) {
-        this.jsonType = 'Praxly_double';
         this.json = node;
         this.value = parseFloat(value);
         this.realType = TYPES.DOUBLE;
@@ -422,7 +417,6 @@ class Praxly_double {
 class Praxly_float {
 
     constructor(value, node) {
-        this.jsonType = 'Praxly_double';
         this.json = node;
         this.value = parseFloat(value);
         this.realType = TYPES.FLOAT;
@@ -437,7 +431,6 @@ class Praxly_boolean {
 
     constructor(value, node) {
         this.json = node;
-        this.jsonType = 'Praxly_boolean';
         this.value = value;
         this.realType = TYPES.BOOLEAN;
     }
@@ -452,7 +445,6 @@ class Praxly_char {
     constructor(value, node) {
         this.value = value;
         this.json = node;
-        this.jsonType = 'Praxly_String';
         this.realType = TYPES.CHAR;
     }
 
@@ -464,7 +456,6 @@ class Praxly_char {
 class Praxly_String {
 
     constructor(value, node) {
-        this.jsonType = 'Praxly_String';
         this.json = node;
         this.value = value;
         this.realType = TYPES.STRING;
@@ -478,7 +469,6 @@ class Praxly_String {
 class Praxly_null {
 
     constructor(value, node) {
-        this.jsonType = 'Praxly_null';
         this.json = node;
         this.value = value;
         this.realType = TYPES.NULL;
@@ -494,7 +484,6 @@ class Praxly_array_literal {
     constructor(elements, node) {
         this.elements = elements;
         this.json = node;
-        this.jsonType = 'Praxly_array';
 
         // set array type to "largest type" of element
         let types = ["boolean", "char", "short", "int", "float", "double", "String"];
@@ -520,7 +509,6 @@ class Praxly_array_create {
         this.varType = varType;
         this.arrayLength = arrayLength;
         this.json = node;
-        this.jsonType = 'Praxly_array_create';
     }
 
     async evaluate(environment) {
@@ -538,8 +526,8 @@ export function valueToString(child, quotes, line) {
         throw new PraxlyError("no value returned from void procedure", line);
     }
     var result;
-    if (child.jsonType === 'Praxly_array') {
-        // always show quote marks for arrays
+    if (child instanceof Praxly_array_literal) {
+        // always show curly braces for arrays
         let values = child.elements.map((element) => valueToString(element, true, line));
         result = '{' + values.join(", ") + '}';
     } else {

--- a/src/ast.js
+++ b/src/ast.js
@@ -336,6 +336,9 @@ export function createExecutable(tree) {
             });
             return new Praxly_array_literal(args, tree);
 
+        case NODETYPES.ARRAY_CREATE:
+            return new Praxly_array_create(tree.elemType, tree.varType, tree.arrayLength,tree);
+
         case NODETYPES.ARRAY_REFERENCE:
             return new Praxly_array_reference(tree.name, createExecutable(tree.index), tree);
 
@@ -507,6 +510,26 @@ class Praxly_array_literal {
 
     async evaluate(environment) {
         return this;
+    }
+}
+
+class Praxly_array_create {
+
+    constructor(elemType, varType, arrayLength, node) {
+        this.elemType = elemType;
+        this.varType = varType;
+        this.arrayLength = arrayLength;
+        this.json = node;
+        this.jsonType = 'Praxly_array_create';
+    }
+
+    async evaluate(environment) {
+        let args = [];
+        for (let i = 0; i < this.arrayLength; i++) {
+            args.push(litNode_new(this.elemType, 0, this.json));
+        }
+
+        return new Praxly_array_literal(args, this.json);
     }
 }
 

--- a/src/blocks2tree.js
+++ b/src/blocks2tree.js
@@ -107,7 +107,7 @@ export const makeGenerator = () => {
             blockID: block.id,
             type: NODETYPES.BUILTIN_FUNCTION_CALL,
             args: [
-              praxlyGenerator[expression?.type](expression),
+                praxlyGenerator[expression?.type](expression),
             ],
         });
     }
@@ -119,7 +119,7 @@ export const makeGenerator = () => {
             blockID: block.id,
             type: NODETYPES.BUILTIN_FUNCTION_CALL,
             args: [
-              praxlyGenerator[expression?.type](expression),
+                praxlyGenerator[expression?.type](expression),
             ],
         });
     }
@@ -131,7 +131,7 @@ export const makeGenerator = () => {
             blockID: block.id,
             type: NODETYPES.BUILTIN_FUNCTION_CALL,
             args: [
-              praxlyGenerator[expression?.type](expression),
+                praxlyGenerator[expression?.type](expression),
             ],
         });
     }
@@ -143,7 +143,7 @@ export const makeGenerator = () => {
             blockID: block.id,
             type: NODETYPES.BUILTIN_FUNCTION_CALL,
             args: [
-              praxlyGenerator[expression?.type](expression),
+                praxlyGenerator[expression?.type](expression),
             ],
         });
     }
@@ -239,6 +239,23 @@ export const makeGenerator = () => {
             index: praxlyGenerator[index?.type](index),
             isArray: true,
         })
+    }
+
+    praxlyGenerator['praxly_array_create_block'] = (block) => {
+        var varType = block.getFieldValue('VARTYPE');
+        var variableName = block.getFieldValue("VARIABLENAME");
+        var elemType = block.getFieldValue('ELEMTYPE');
+        var arrayLength = block.getInputTargetBlock('LENGTH');
+
+        return customizeMaybe(block, {
+            type: NODETYPES.ARRAY_CREATE,
+            varType: varType,
+            name: variableName,
+            elemType: elemType,
+            arrayLength: praxlyGenerator[arrayLength?.type](arrayLength),
+            isArray: true,
+            blockID: block.id,
+        });
     }
 
     // NOTE: praxly_literal_block and praxly_variable_block work the same way.
@@ -641,7 +658,7 @@ export const makeGenerator = () => {
         const index = block.getInputTargetBlock('INDEX');
         return customizeMaybe(block, {
             blockID: block.id,
-            name : procedureName,
+            name: procedureName,
             type: NODETYPES.SPECIAL_STRING_FUNCCALL,
             left: praxlyGenerator[expression?.type](expression),
             right: {
@@ -714,7 +731,7 @@ export const makeGenerator = () => {
             right: {
                 name: procedureName,
                 args: [praxlyGenerator[param1?.type](param1),
-                       praxlyGenerator[param2?.type](param2)],
+                praxlyGenerator[param2?.type](param2)],
                 type: NODETYPES.FUNCCALL
             }
         });

--- a/src/blocks2tree.js
+++ b/src/blocks2tree.js
@@ -107,7 +107,7 @@ export const makeGenerator = () => {
             blockID: block.id,
             type: NODETYPES.BUILTIN_FUNCTION_CALL,
             args: [
-                praxlyGenerator[expression?.type](expression),
+              praxlyGenerator[expression?.type](expression),
             ],
         });
     }
@@ -119,7 +119,7 @@ export const makeGenerator = () => {
             blockID: block.id,
             type: NODETYPES.BUILTIN_FUNCTION_CALL,
             args: [
-                praxlyGenerator[expression?.type](expression),
+              praxlyGenerator[expression?.type](expression),
             ],
         });
     }
@@ -131,7 +131,7 @@ export const makeGenerator = () => {
             blockID: block.id,
             type: NODETYPES.BUILTIN_FUNCTION_CALL,
             args: [
-                praxlyGenerator[expression?.type](expression),
+              praxlyGenerator[expression?.type](expression),
             ],
         });
     }
@@ -143,7 +143,7 @@ export const makeGenerator = () => {
             blockID: block.id,
             type: NODETYPES.BUILTIN_FUNCTION_CALL,
             args: [
-                praxlyGenerator[expression?.type](expression),
+              praxlyGenerator[expression?.type](expression),
             ],
         });
     }
@@ -731,7 +731,7 @@ export const makeGenerator = () => {
             right: {
                 name: procedureName,
                 args: [praxlyGenerator[param1?.type](param1),
-                praxlyGenerator[param2?.type](param2)],
+                       praxlyGenerator[param2?.type](param2)],
                 type: NODETYPES.FUNCCALL
             }
         });

--- a/src/common.js
+++ b/src/common.js
@@ -80,6 +80,7 @@ export const NODETYPES = {
     FUNCCALL:                       "FUNCTION_CALL",
     RETURN:                         "RETURN",
     ARRAY_LITERAL:                  "ARRAY_LITERAL",
+    ARRAY_CREATE:                   "ARRAY_CREATE",
     ARRAY_REFERENCE:                "ARRAY_REFERENCE",
     ARRAY_REFERENCE_ASSIGNMENT:     "ARRAY_REFERENCE_ASSIGNMENT", // remove?
     SPECIAL_STRING_FUNCCALL:        "SPECIAL_STRING_FUNCCALL",

--- a/src/newBlocks.js
+++ b/src/newBlocks.js
@@ -288,6 +288,53 @@ export function definePraxlyBlocks(workspace) {
       "tooltip": "Declares and initializes an array",
       "helpUrl": ""
     },
+    {
+      "type": "praxly_array_create_block",
+      "message0": "%1[] %2 ⬅ %3[%4]",
+      "args0": [
+        {
+          "type": "field_dropdown",
+          "name": "VARTYPE",
+          "options": [
+            ["boolean", NODETYPES.BOOLEAN],
+            ["char", NODETYPES.CHAR],
+            ["double", NODETYPES.DOUBLE],
+            ["float", NODETYPES.FLOAT],
+            ["int", NODETYPES.INT],
+            ["short", NODETYPES.SHORT],
+            ["String", NODETYPES.STRING],
+          ]
+        },
+        {
+          "type": "field_input",
+          "name": "VARIABLENAME",
+          "text": "arrayName"
+        },
+        {
+          "type": "field_dropdown",
+          "name": "ELEMTYPE",
+          "options": [
+            ["boolean", NODETYPES.BOOLEAN],
+            ["char", NODETYPES.CHAR],
+            ["double", NODETYPES.DOUBLE],
+            ["float", NODETYPES.FLOAT],
+            ["int", NODETYPES.INT],
+            ["short", NODETYPES.SHORT],
+            ["String", NODETYPES.STRING],
+          ]
+        },
+        {
+          "type": "input_value",
+          "name": "LENGTH",
+        }
+      ],
+      "inputsInline": true,
+      "previousStatement": null,
+      "nextStatement": null,
+      "style": 'variable_blocks',
+      "tooltip": "Initialize and declare an array of desired length", // of length n?
+      "helpUrl": ""
+    },
     { // variables 6
       "type": "praxly_array_reference_reassignment_block",
       "message0": "%1[%2] ⬅%3 %4",

--- a/src/newBlocks.js
+++ b/src/newBlocks.js
@@ -293,7 +293,6 @@ export function definePraxlyBlocks(workspace) {
       "message0": "%1[] %2 ⬅ %3[%4]",
       "args0": [
         {
-          // TODO set initial type to int
           "type": "field_dropdown",
           "name": "VARTYPE",
           "options": [
@@ -333,7 +332,7 @@ export function definePraxlyBlocks(workspace) {
       "previousStatement": null,
       "nextStatement": null,
       "style": 'variable_blocks',
-      "tooltip": "Initialize and declare an array of desired length", // of length n?
+      "tooltip": "Initialize and declare an array of desired length",  // of length n?
       "helpUrl": ""
     },
     { // variables 6

--- a/src/newBlocks.js
+++ b/src/newBlocks.js
@@ -297,11 +297,11 @@ export function definePraxlyBlocks(workspace) {
           "type": "field_dropdown",
           "name": "VARTYPE",
           "options": [
+            ["int", NODETYPES.INT],
             ["boolean", NODETYPES.BOOLEAN],
             ["char", NODETYPES.CHAR],
             ["double", NODETYPES.DOUBLE],
             ["float", NODETYPES.FLOAT],
-            ["int", NODETYPES.INT],
             ["short", NODETYPES.SHORT],
             ["String", NODETYPES.STRING],
           ]
@@ -315,11 +315,11 @@ export function definePraxlyBlocks(workspace) {
           "type": "field_dropdown",
           "name": "ELEMTYPE",
           "options": [
+            ["int", NODETYPES.INT],
             ["boolean", NODETYPES.BOOLEAN],
             ["char", NODETYPES.CHAR],
             ["double", NODETYPES.DOUBLE],
             ["float", NODETYPES.FLOAT],
-            ["int", NODETYPES.INT],
             ["short", NODETYPES.SHORT],
             ["String", NODETYPES.STRING],
           ]

--- a/src/newBlocks.js
+++ b/src/newBlocks.js
@@ -293,6 +293,7 @@ export function definePraxlyBlocks(workspace) {
       "message0": "%1[] %2 ⬅ %3[%4]",
       "args0": [
         {
+          // TODO set initial type to int
           "type": "field_dropdown",
           "name": "VARTYPE",
           "options": [

--- a/src/text2tree.js
+++ b/src/text2tree.js
@@ -688,9 +688,12 @@ class Parser {
 
           // built-in function call
           case NODETYPES.BUILTIN_FUNCTION_CALL:
-          case 'Type':  // type conversion function
-            if (this.has_ahead('(')) {
+          case 'Type':
+            if (this.has_ahead('(')) {  // type conversion function
               return this.parse_builtin_function_call(line);
+            }
+            if (this.has_ahead('[')) {  // create array expression
+                // TODO parse array length and closing bracket
             }
             else {
               // parse as 'Location' instead (Ex: variable named max)
@@ -813,7 +816,7 @@ class Parser {
   // this one kinda a mess ngl, but my goal is to support variable initialization and assignment all together
   parse_funcdecl_or_vardecl() {
 
-    // return type
+    // variable/return type
     var isArray = false;
     var type = NODETYPES.VARDECL;
     var vartype = this.getCurrentToken().value;
@@ -846,6 +849,8 @@ class Parser {
       this.advance();
       result.value = this.parse_expression();
       result.endIndex = this.tokens[this.i - 1].endIndex;
+
+      // TODO if applicable, rebuild the result as NODETYPES.ARRAY_CREATE
     }
 
     // procedure definition

--- a/src/text2tree.js
+++ b/src/text2tree.js
@@ -698,12 +698,17 @@ class Parser {
                 var elemType = this.advance().value;
                 // opening bracket
                 this.advance();
-                var arrayLength = this.parse_expression(line);
-                // closing bracket
                 if (this.has(']')) {
+                    textError('parsing', "missing array length", this.getCurrentLine());
                     this.advance();
                 } else {
-                    textError('parsing', "didn't detect closing bracket in the array length", this.getCurrentLine());
+                    var arrayLength = this.parse_expression();
+                    // closing bracket
+                    if (this.has(']')) {
+                        this.advance();
+                    } else {
+                        textError('parsing', "didn't detect closing bracket in the array length", this.getCurrentLine());
+                    }
                 }
                 return {
                     type: NODETYPES.ARRAY_CREATE,
@@ -874,7 +879,7 @@ class Parser {
       result.endIndex = this.tokens[this.i - 1].endIndex;
 
       // special case: array initialization
-      if (result.value.type == NODETYPES.ARRAY_CREATE) {
+      if (result.value?.type == NODETYPES.ARRAY_CREATE) {
         result.value.varType = result.varType;
         result.value.name = result.name;
         return result.value;

--- a/src/text2tree.js
+++ b/src/text2tree.js
@@ -693,7 +693,28 @@ class Parser {
               return this.parse_builtin_function_call(line);
             }
             if (this.has_ahead('[')) {  // create array expression
-                // TODO parse array length and closing bracket
+                var elemType = this.advance().value;
+                // opening bracket
+                this.advance();
+                var arrayLength = this.parse_expression(line);
+                // closing bracket
+                if (this.has(']')) {
+                    this.advance();
+                } else {
+                    textError('parsing', "didn't detect closing bracket in the array length", this.getCurrentLine());
+                }
+                return {
+                    type: NODETYPES.ARRAY_CREATE,
+                    varType: "type",
+                    name: "name",
+                    elemType: elemType,
+                    arrayLength: arrayLength,
+                    isArray: true,
+                    blockID: "code",
+                    line: line,
+                    startIndex: startIndex,
+                    endIndex: this.getCurrentToken().endIndex,
+                };
             }
             else {
               // parse as 'Location' instead (Ex: variable named max)
@@ -850,7 +871,12 @@ class Parser {
       result.value = this.parse_expression();
       result.endIndex = this.tokens[this.i - 1].endIndex;
 
-      // TODO if applicable, rebuild the result as NODETYPES.ARRAY_CREATE
+      // special case: array initialization
+      if (result.value.type == NODETYPES.ARRAY_CREATE) {
+        result.value.varType = result.varType;
+        result.value.name = result.name;
+        return result.value;
+      }
     }
 
     // procedure definition

--- a/src/text2tree.js
+++ b/src/text2tree.js
@@ -689,10 +689,12 @@ class Parser {
           // built-in function call
           case NODETYPES.BUILTIN_FUNCTION_CALL:
           case 'Type':
-            if (this.has_ahead('(')) {  // type conversion function
+            if (this.has_ahead('(')) {
+              // type conversion function
               return this.parse_builtin_function_call(line);
             }
-            if (this.has_ahead('[')) {  // create array expression
+            if (this.has_ahead('[')) {
+                // create array expression
                 var elemType = this.advance().value;
                 // opening bracket
                 this.advance();

--- a/src/toolbox.js
+++ b/src/toolbox.js
@@ -96,6 +96,20 @@ export const toolbox = {
         },
         {
           'kind': 'block',
+          'type': 'praxly_array_create_block',
+          'inputs': {
+            'LENGTH': {
+              'shadow': {
+                'type': 'praxly_literal_block',
+                'fields': {
+                  'LITERAL': 10,
+                }
+              }
+            }
+          }
+        },
+        {
+          'kind': 'block',
           'type': 'praxly_array_reference_reassignment_block',
           'inputs': {
             'INDEX': {

--- a/src/tree2blocks.js
+++ b/src/tree2blocks.js
@@ -473,16 +473,14 @@ export const tree2blocks = (workspace, node) => {
             var result = params;
             break;
 
-        case NODETYPES.ARRAY_CREATE:
-            var result = workspace.newBlock('praxly_array_create_block');
+        case NODETYPES.ARRAY_CREATE:  // similar to ARRAY_ASSIGNMENT
             var arrayLength = tree2blocks(workspace, node?.arrayLength);
-
+            var result = workspace.newBlock('praxly_array_create_block');
             result.setFieldValue(node?.varType, 'VARTYPE');
             result.setFieldValue(node?.name, "VARIABLENAME");
             result.setFieldValue(node?.elemType, "ELEMTYPE");
             result.getInput("LENGTH").connection.connect(arrayLength?.outputConnection);
             break;
-
 
         case NODETYPES.ARRAY_REFERENCE_ASSIGNMENT:
             var result = workspace.newBlock('praxly_array_reference_reassignment_block');

--- a/src/tree2blocks.js
+++ b/src/tree2blocks.js
@@ -473,6 +473,17 @@ export const tree2blocks = (workspace, node) => {
             var result = params;
             break;
 
+        case NODETYPES.ARRAY_CREATE:
+            var result = workspace.newBlock('praxly_array_create_block');
+            var arrayLength = tree2blocks(workspace, node?.arrayLength);
+
+            result.setFieldValue(node?.varType, 'VARTYPE');
+            result.setFieldValue(node?.name, "VARIABLENAME");
+            result.setFieldValue(node?.elemType, "ELEMTYPE");
+            result.getInput("LENGTH").connection.connect(arrayLength?.outputConnection);
+            break;
+
+
         case NODETYPES.ARRAY_REFERENCE_ASSIGNMENT:
             var result = workspace.newBlock('praxly_array_reference_reassignment_block');
             result.setFieldValue(node.location.name, "VARIABLENAME");

--- a/src/tree2text.js
+++ b/src/tree2text.js
@@ -325,6 +325,9 @@ export const tree2text = (node, indentation) => {
             result += '}';
             return result;
 
+        case NODETYPES.ARRAY_CREATE:
+            return node.varType + "[] " + node.name + " ← " + node.elemType + '[' + tree2text(node.arrayLength) + ']';
+
         case NODETYPES.ARRAY_REFERENCE:
             result = node.name + '[';
             var expression = tree2text(node.index, 0) + ']';


### PR DESCRIPTION
Ellona added the ability to create an array of n elements with default values. For example: `int[] scores ← int[5]`.